### PR TITLE
7.7 EN notes

### DIFF
--- a/slides/en/index.html
+++ b/slides/en/index.html
@@ -90,10 +90,15 @@
           </div>
 
           <aside class="notes">
+            1<br /><br />
+            Welcome<br />
+            Introduction of myself<br />
             Presentation of Bonita<br />
             Creation of 1st process and application<br />
             Mix of theoretical presentation and practical exercises<br />
-            Time to answer your questions
+            Time to answer your questions: after each chapter<br />
+            Community forum<br />
+            Contact form bonitasoft.com
           </aside>
         </section>
 
@@ -106,6 +111,14 @@
             <li>Start the Studio and click on Portal button</li>
             <li>We recommend to use Chrome or Firefox as your default web browser for development</li>
           </ul>
+          
+          <aside class="notes">
+            2<br /><br />
+            Resources: slides, exercises, solutions, etc. [GitHub - latest release]<br />
+            Need the Studio to follow the session<br />
+            Community vs Enterprise editions (Support, access to professional services &amp; additional features)<br />
+            Browser recommendation: better tooling like debug &amp; co
+          </aside>
         </section>
 
         <section>
@@ -121,6 +134,10 @@
             <li>BPM-based applications</li>
             <li>Deployment</li>
           </ul>
+          <aside class="notes">
+            1<br /><br />
+            3:30h of time
+          </aside>
         </section>
 
         <section>
@@ -130,6 +147,7 @@
           <p>Optimize processes</p>
 
           <aside class="notes">
+            1:30<br /><br />
             Ensure tasks are performed in the right order, by the appropriate persons and timely<br/>
             Guarantee that process can be reproduced efficiently<br/>
             Tracking and continuous improvement with software such as Bonita
@@ -154,6 +172,7 @@
             </table>
 
             <aside class="notes">
+              0:30<br /><br />
               Studio is a standalone IDE for developers (screenshot on next slide).<br/>
               Studio contains an embedded Platform used for single developer testing.<br/>
               Production-ready platforms are deployed on dedicated servers.
@@ -165,6 +184,7 @@
             <img src="images/screenshot_studio_diagram.png" alt="Bonita Studio: Diagram Editor" />
 
             <aside class="notes">
+              1:30<br /><br />
               Studio is an Eclipse based IDE. Requires a JVM (version 8).<br/>
               Allows creation of process diagrams which contain one or several processes (recommend one process per diagram).<br/>
               Different steps: process modeling, data model definition, form and pages design, connectors setup...<br/>
@@ -177,6 +197,8 @@
             <img class="no-margin" src="images/screenshot_ui_designer.png" alt="Bonita Studio: UI Designer">
 
             <aside class="notes">
+            1<br /><br />
+            Easy to use, mockup to production ready displays<br />
             Browser based. Using AngularJS and Bootstrap. Allows to create custom widgets.
             </aside>
           </section>
@@ -193,7 +215,10 @@
             </ul>
 
             <aside class="notes">
+            1.30<br /><br />
             All interactions (Portal and other) with the Engine are managed with Bonita APIs.<br/>
+            Bundles (Tomcat and WildFly) and Docker image are available to simplify the server installation<br />
+            Enterprise edition provides features to handle deployment an maintenance on the cloud (AWS or other)
             </aside>
           </section>
 
@@ -205,6 +230,7 @@
             <img class="no-margin" src="images/screenshot_portal_inbox.png" alt="Bonita Portal: Task Inbox" height="400" />
 
             <aside class="notes">
+              30<br /><br />
               Portal uses the Bonita APIs as any client of the Engine
             </aside>
           </section>
@@ -216,6 +242,8 @@
             <img class="no-margin" src="images/screenshot_form.png" alt="Bonita form" height="400" />
 
             <aside class="notes">
+              1.00<br /><br />
+              definition of form (display and get input as part of the process execution)
             </aside>
           </section>
 
@@ -225,6 +253,10 @@
             <img class="no-margin" src="images/screenshot_application.png" alt="Bonita application" height="400" />
 
             <aside class="notes">
+              1.30<br /><br />
+              Global view that use pages like dashboards to display and give access to actions<br />
+              Everything is defined in the UID and hosted by the Bonita plaform<br />
+              Business specific which makes it usually better than generic task list that might not be as convenient
             </aside>
           </section>
         </section>
@@ -254,9 +286,14 @@
             <p>Elements are linked together by Transitions <span style="margin:0 0 0 20px;">&#8594;</span></p>
 
             <aside class="notes">
+              4.30<br /><br />
               OMG = Object Management Group, founded several standards such as UML<br/>
+              Not business limitations<br />
+              Not Bonita specific<br />
               Shapes (BPMN standard): circle = event, rectangle = activity<br/>
-              Colors (Bonita specific): green = start, blue = intermediate, red = end
+              Colors (Bonita specific): green = start, blue = intermediate, red = end<br />
+              [Studio - language (EN/ES/FR by default &amp; crowdin community), import BOS/BPMN, diagram, whiteboard, process, properties, lane, task, event, switch between item types<br />
+              Documentation for details of all elements in the palette
             </aside>
           </section>
 
@@ -281,11 +318,14 @@
               <img class="no-margin" src="images/bpmn_gateway_design.png" alt="Symetrical gateway design"/>
 
               <aside class="notes">
-                - Exclusive: use default TR and make sure only one condition is true among outgoing TRs<br/>
-                - Exclusive: only one incoming TR should reach the gateway.<br/>
-                - Parallel: all outgoing TR fired at the same time (no condition allowed).<br/>
-                - Parallel: all incoming TR are waited for even if some can never be reached due to bad design.<br/>
-                - Inclusive: used when dealing with parallel gateways with conditions
+                5<br /><br />
+                Exclusive: use default TR and make sure only one condition is true among outgoing TRs<br/>
+                Exclusive: only one incoming TR should reach the gateway.<br/>
+                Parallel: all outgoing TR fired at the same time (no condition allowed).<br/>
+                Parallel: all incoming TR are waited for even if some can never be reached due to bad design.<br/>
+                Inclusive: used when dealing with parallel gateways with conditions<br />
+                Best practice: explicit, symmetric and default<br />
+                [Studio - parallel / exclusive / inclusive gateways, order of condition evaluation, validation]
               </aside>
             </section>
 
@@ -298,9 +338,19 @@
             </div>
 
             <aside class="notes">
-              - Demonstrate how to check process history using the administrator view. Speak about the value of graphical monitoring from Enterprise edition.<br/>
-              - Demonstrate how to export the content of the workspace (one diagram / the whole workspace).<br/>
-              - Demonstrate how to import a correction and deal with conflict.
+              2.00<br /><br />
+              Sump the content of the exercise: build a basic but running leave request process for a company<br />
+              Exercise correction resources are available: one BOS file per exercise<br />
+              Useful because exercises are iterations on the same process<br />
+              [Studio - save button, export, import, conflict]<br />
+              [Portal - Administrator view with graphical monitoring (Enterprise edition)]
+              <br />
+              25 - WAIT / ANSWER QUESTIONS<br />
+              <br /><br />
+              5<br /><br />
+              Embedded engine in Studio to test development<br />
+              [Studio - run a case of exercise 1, process instantiation form, assign/execute task from task list page, administrator perspective to see archived case]<br />
+              [Studio - edit the condition to false, run another case and show other task]
             </aside>
           </section>
         </section>
@@ -320,7 +370,9 @@
             </div>
 
             <aside class="notes">
-              Forms data are for example used to store the result of a REST API call (to get BDM value) in order to display it in a form.
+              1.30<br /><br />
+              BDM: complex type with fields, dedicated DB with automatic administration, accessible by API<br />
+              Form: used to store the result of a REST API call (like getting BDM data)
             </aside>
           </section>
 
@@ -353,8 +405,11 @@
             </p>
 
             <aside class="notes">
+              4<br /><br />
               DB storage guarantees that data is safely kept in case of server shut down (expected or not).<br/>
-              Never try to R/W data directly from Bonita DB, use the APIs to do so.
+              Never try to R/W data directly from Bonita DB, use the APIs to do so.<br />
+              Document: basic in Bonita but could use CMS using connectors like Alfresco or Sharepoint<br />
+              [Studio - show data in the process to execute the flow]
             </aside>
           </section>
 
@@ -367,6 +422,12 @@
               <li>Execute a human task</li>
             </ul>
             <p>Contributes to the decoupling of process logic and user interface.</p>
+            <aside class="notes">
+              2.30<br /><br />
+              Invalid contract will fail<br />
+              [Studio - process &amp; human task contracts, approval from user form example]<br />
+              In case you want to use your own forms, the contract is the interface that warranty the right execution
+            </aside>
           </section>
           
           <section>
@@ -375,6 +436,7 @@
             <img class="no-margin" src="images/data_from_forms_to_process_variables.png" alt="Data flow from forms to process variables">
 
             <aside class="notes">
+              2.30<br /><br />
             When the user inputs some data in a form they are first stored in JavaScript variables.<br/>
             When user click on the submit button, a REST API call is performed to the Engine API to instruct the Engine to start a new process instance or execute a task. This call carry the value of a JavaScript variable associated with the submit button. REST API call is an HTTP request that carry out data as JSON.<br/>
             Engine will check that received JSON data match the contract definition and validation rules. If it match, the data are now stored in the contract variables.<br />
@@ -386,6 +448,13 @@
             <h2>Exercise 2</h2>
             <p class="exercise-title">Adding data and specifying contracts</p>
           </section>
+            <aside class="notes">
+              6<br /><br />
+              Define data model in the process we started, add business variable, edit the condition based on the related contract input<br/>
+              [Studio - BDM definition, BO with attributes, deploy in test environment, add business variable in process, create contract from this reference and the initialization script, add contract input manually, condition expression editor with business data access, operation to update BDM attribute on a task, start a case, show generated form with the contract info]<br/>
+              <br/>
+              15 - WAIT / ANSWER QUESTIONS<br />
+            </aside>
         </section>
 
         <section>
@@ -407,6 +476,11 @@
             </ul>
 
             <aside class="notes">
+              4<br /><br />
+              Form: return some input from the end user, associated to process (process instantiation or human task), triggers execution from engine perspective<br />
+              Page: does not return anything, display information and optionally provide access to actions<br />
+              [Studio - human task form, process instantiation form, case overview]<br />
+              [UID - open]
             </aside>
           </section>
 
@@ -416,7 +490,9 @@
             <p>Custom widgets can be created with the UI Designer</p>
 
             <aside class="notes">
-              Demonstrate the usage of web browser console to debug forms/contracts.<br/>
+              4<br /><br />
+              Community contribution<br />
+              [UID, create new artifact, overview of features with HELP redirection, use default Widget like button, create CW to be includes into the form, Chrome dev tools to debug forms/contracts]<br/>
               http://localhost:8080/bonita/API/bdm/businessData/com.company.model.VacationRequest?q=find&p=0&c=10
             </aside>
           </section>
@@ -427,7 +503,10 @@
             <img class="no-margin" src="images/display_business_variables_in_forms.png" alt="Data flow from process variables to forms">
 
             <aside class="notes">
-            When you create a new form you can use some predefined JavaScript variables.<br/>
+            8<br /><br />
+            The UI usually displays business information that is stored<br />
+            [Studio &amp; UID &amp; H2 interface - explained the following based on exercise solution, run it with DEV TOOL enabled]<br />
+            When you create a new form you can use some predefined JavaScript variables to make the link with business variables and documents linked to the context<br/>
             The "context" variable give some information about the task and process instance associated with the visible form.<br/>
             "context" variable have attribute that match the name of process variable with suffix _ref. Those variable have a "link" attribute that define the URL of the API to call in order to retrieve the business variable value.<br/>
             The business variable value is actually a reference to a row in a table of the business database.<br/>
@@ -438,6 +517,11 @@
           <section>
             <h2>Exercise 3</h2>
             <p class="exercise-title">Creating forms</p>
+            <aside class="notes">
+            Build a form from scratch<br/>
+            <br/>
+            20 - WAIT / ANSWER QUESTIONS<br />
+            </aside>
           </section>
         </section>
 
@@ -465,16 +549,30 @@
             </table>
 
             <aside class="notes">
+              8<br /><br />
+              Explain what is a candidate and assignee<br />
+              Actor can be related to process instantiation, single human task or lane<br />
+              [Studio - actors list and reference to process, initiator]<br />
               Actors allow to automatically update task visibility when organization changes.<br/>
+              Actor can be mapped to a subset of the organization using actor mapping: lists of users, groups, roles and memberships<br />
+              [Studio &amp; Portal - edit process configuration actor mappings, run it]<br />
               Actors cannot use any live data (business variables, external system information...) whereas filters can.<br/>
               Filters are executed only once when task starts. They can be run again with API call.<br />
-              If you already have information about your organization stored in an LDAP/Active Directory server Enterprise Edition provide a tool that will save you time by dealing with the synchronization between LDAP/AD and Bonita user database.
+              [Studio &amp; Portal - change task actor to actor filter, run it]<br />
+              If you already have information about your organization stored in an LDAP/Active Directory server Enterprise edition provide a tool that will save you time by dealing with the synchronization between LDAP/AD and Bonita user database.<br />
+              On the authentication purpose, Bonita provides features to use SSO (SAML V2, CAS), LDAP and Kerberos.
             </aside>
           </section>
 
           <section>
             <h2>Exercise 4</h2>
             <p class="exercise-title">Configuring actors</p>
+            
+            <aside class="notes">
+              Configure actors in the process<br />
+              <br/>
+              15 - WAIT / ANSWER QUESTIONS<br />
+            </aside>
           </section>
         </section>
 
@@ -490,15 +588,21 @@
             </ul>
 
             <aside class="notes">
+              5<br /><br />
               Connectors can be placed at the start or the end of a process or a task.<br/>
               Any data type or groovy script can be used as I/O.<br/>
-              When possible prefer connectors over scripts for increased performance, error handling (Enterprise Edition).
+              When possible prefer connectors over scripts for increased performance, error handling (Enterprise Edition).<br />
+              [Studio - add connector, set I/O]<br />
+              Connector dependencies are used in priority to avoid conflict with Engine ones: specific classloaders are used to make it possible
             </aside>
           </section>
 
           <section>
             <h2>Exercise 5</h2>
             <p class="exercise-title">Using a connector to send an email</p>
+            <aside class="notes">
+              20 - WAIT / ANSWER QUESTIONS<br />
+            </aside>
           </section>
         </section>
 
@@ -514,11 +618,26 @@
               <li>Controller is a set of processes</li>
             </ul>
             <p>Applications are deployed and hosted in Bonita Portal</p>
+            <aside class="notes">
+              14<br /><br />
+              Business data is central to processes that make the overall application<br />
+              We can live update most of the elements (process configuration, BDM definition, etc...)<br />
+              [Portal - edit process configuration]<br />
+              Page is a type of artifact that is used in the view that is specific to the application layer<br />
+              [Studio &amp; UID &amp; Portal - show the result of the exercise and explain the dashboard page implementation of the leaving request application, use preview]<br />
+              To have an application, we need a descriptor that will define how resources will be glued together<br />
+              [Studio - show the descriptor and deploy it]<br />
+              [Portal - show edition of the deployed application with new version of the dashboard page, menus, etc.]
+            </aside>
           </section>
 
           <section>
             <h2>Exercise 6</h2>
             <p class="exercise-title">Create a leave request application</p>
+            
+            <aside class="notes">
+              20 - WAIT / ANSWER QUESTIONS<br />
+            </aside>
           </section>
         </section>
 
@@ -543,7 +662,10 @@
           </table>
 
           <aside class="notes">
-            When running processes from the Studio the deploy procedure is automated.
+            2.30<br /><br />
+            When running processes from the Studio the deploy procedure is automated to ease tests<br />
+            This does multiple steps<br />
+            [Studio &amp; Portal - build, deploy, process configuration]
           </aside>
          </section>
 
@@ -564,8 +686,12 @@
             <td>Portal</td>
           </tr>
           </table>
-          
           <aside class="notes">
+            2.30<br /><br />
+		    The final purpose of all this development is to get business applications deployed on a server<br />
+			The process part is only the controller part<br />
+			The deployment of such an application has to be done in a specific order as there are dependencies between the developed elements<br />
+			For real server deployment, it has to be follow few rules that can be done manually with the Portal or be automated using CI/CD with APIs
             Mention BCD for automated command line/Jnkeins build and deployment (Enterprise Edition).
           </aside>
          </section>


### PR DESCRIPTION
Ad notes for the 17 first minutes of presentation
Add notes until 105.30
Complete the note extensions
Add missed line breaks in asides
Rework the timeline info
Syntax fix
Update English slides for 7.7.
Use Enterprise Edition instead of Subscription in slides comments.
Add a reference to BCD in deployment slide comment to promote it.
Replace tabs with spaces
Encode & characters
Add few elements in the notes